### PR TITLE
fixing margin of the share icon

### DIFF
--- a/src/PwaInstallPopupIOS/styles.scss
+++ b/src/PwaInstallPopupIOS/styles.scss
@@ -29,7 +29,7 @@
 
       img.small {
         height: 20px;
-        margin: -5 5px;
+        margin: -5px 5px;
       }
       div {
         line-height: 20px;


### PR DESCRIPTION
Without the correct syntax, the whole statement is ignored. 
![image](https://user-images.githubusercontent.com/32771/110493679-23257e00-80f3-11eb-9f01-06442d5b8a8c.png)

resulting in:

![image](https://user-images.githubusercontent.com/32771/110493614-14d76200-80f3-11eb-9e1f-2a2e626c1f9c.png)
